### PR TITLE
Add ssh/scp command line options config element

### DIFF
--- a/plugins/vacation_sieve/config-default.inc.php
+++ b/plugins/vacation_sieve/config-default.inc.php
@@ -42,7 +42,8 @@ $rcmail_config['vacation_sieve'] = array(
         # SSH Mode example
         # 'user'   => 'vmail',
         # 'host'   => 'localhost',
-        # 'port'   => '22
+        # 'options'   => '-i /path/to/alternate/.ssh/id_rsa -o UserKnownHostsFile=/path/to/alternate/.ssh/known_hosts',
+        # 'port'   => '22',
 
         # Managesieve Mode example
         # 'ms_activate_script' => true,

--- a/plugins/vacation_sieve/transfer/ssh.php
+++ b/plugins/vacation_sieve/transfer/ssh.php
@@ -13,13 +13,15 @@ class SSHTransfer extends SieveTransfer
 
         $user = $this->params['user'];
         $host = $this->params['host'];
+        $options = $this->params['options'];
 
         if ( !$user ) $user = 'vmail';
         if ( !$host ) $host = 'localhost';
+        if ( !$options ) $options = '';
 
         # Copy the file
         $status = 0;
-        $command = sprintf("/usr/bin/scp -q %s@%s:%s '%s'", $user, $host, $path, $tmpFile);
+        $command = sprintf("/usr/bin/scp -q %s %s@%s:%s '%s'", $options, $user, $host, $path, $tmpFile);
         system($command, $status);
 
         $script = file_get_contents($tmpFile);
@@ -35,13 +37,15 @@ class SSHTransfer extends SieveTransfer
 
         $user = $this->params['user'];
         $host = $this->params['host'];
+        $options = $this->params['options'];
 
         if ( !$user ) $user = 'vmail';
         if ( !$host ) $host = 'localhost';
+        if ( !$options ) $options = '';
 
         # Copy the file
         $status = 0;
-        $command = sprintf("/usr/bin/scp -q '%s' %s@%s:%s", $tmpFile, $user, $host, $path);
+        $command = sprintf("/usr/bin/scp -q %s '%s' %s@%s:%s", $options, $tmpFile, $user, $host, $path);
         system($command, $status);
 
         if ( $status == 0 && !empty($this->params['sievecbin']) )
@@ -49,7 +53,7 @@ class SSHTransfer extends SieveTransfer
             # Compile the file. I don't think this is necessary with Dovecot
             # as it compiles the files on the fly by default.
             $sievecbin = $this->params['sievecbin'];
-            $command = sprintf("/usr/bin/ssh %s@%s '%s \"%s\"'", $user, $host, $sievecbin, $path);
+            $command = sprintf("/usr/bin/ssh %s %s@%s '%s \"%s\"'", $options, $user, $host, $sievecbin, $path);
             system($command, $status);
         }
         else


### PR DESCRIPTION
- Update config file for options + typo
- Update calls to SSH & SCP to call with options

Patch to allow the location of SSH key to be outside that of the httpd home path which is often openly accessible without extra security.
