### PR TITLE
Do not show error for missing sieve scripts

### DIFF
--- a/plugins/vacation_sieve/transfer/managesieve.php
+++ b/plugins/vacation_sieve/transfer/managesieve.php
@@ -59,9 +59,9 @@ class ManagesieveTransfer extends SieveTransfer
                 case SIEVE_ERROR_DEACTIVATE:
                     $this->app->output->show_message('Managesieve: Activation change failed', 'error');
                     break;
-				case 255:
-					$this->app->output->show_message('Managesieve: No sieve scripts found (This can be ignored on first run)', 'info');
-					break;					
+								case 255:
+										$this->app->output->show_message('Managesieve: No sieve scripts found (This can be ignored on first run)', 'info');
+										break;
                 default:
                     $this->app->output->show_message('Managesieve: Unknown error', 'error');
                     break;

--- a/plugins/vacation_sieve/transfer/managesieve.php
+++ b/plugins/vacation_sieve/transfer/managesieve.php
@@ -59,9 +59,9 @@ class ManagesieveTransfer extends SieveTransfer
                 case SIEVE_ERROR_DEACTIVATE:
                     $this->app->output->show_message('Managesieve: Activation change failed', 'error');
                     break;
-								case 255:
-										$this->app->output->show_message('Managesieve: No sieve scripts found (This can be ignored on first run)', 'info');
-										break;
+                case 255:
+                    $this->app->output->show_message('Managesieve: No sieve scripts found (This can be ignored on first run)', 'info');
+                    break;									
                 default:
                     $this->app->output->show_message('Managesieve: Unknown error', 'error');
                     break;

--- a/plugins/vacation_sieve/transfer/managesieve.php
+++ b/plugins/vacation_sieve/transfer/managesieve.php
@@ -59,6 +59,9 @@ class ManagesieveTransfer extends SieveTransfer
                 case SIEVE_ERROR_DEACTIVATE:
                     $this->app->output->show_message('Managesieve: Activation change failed', 'error');
                     break;
+				case 255:
+					$this->app->output->show_message('Managesieve: No sieve scripts found (This can be ignored on first run)', 'info');
+					break;					
                 default:
                     $this->app->output->show_message('Managesieve: Unknown error', 'error');
                     break;


### PR DESCRIPTION
When using a new email account you'd have an 'Unknown error' appear
which was troubling to the user but this is simply a uncaught error.
