### PR TITLE
Some useful little modifications to plugin "identiteam"

### DIFF
--- a/plugins/identiteam/config-default.inc.php
+++ b/plugins/identiteam/config-default.inc.php
@@ -20,6 +20,10 @@ array(
     // LDAP parameters
     'ldap' => array(
         'server' => 'ldap.snakeoil.com',                    // Your LDAP server address
+        'bind_user' => 'ldap_query@snakeoil.com',           // Your LDAP bind user for queries
+        'bind_pass' => 'sercret',                           // Your LDAP bind password
+        'referrals' => 0,                                   // Specifies whether to automatically follow referrals returned by the LDAP server.
+
         'filter_remove_domain' => true,                     // if set to true, the domain name (eg. xxxx@example.com) is removed before the lookup
         'filter' => '(uid=%s)' ,                            // The LDAP filter to use. This is compared with the user' login. use 'mail' if the domain is
                                                             // specified in the login process.

--- a/plugins/identiteam/identiteam.php
+++ b/plugins/identiteam/identiteam.php
@@ -43,6 +43,11 @@ class identiteam extends rcube_plugin
             $this->mail = $this->config['mail'];
 
             $this->server = $this->ldap['server'];
+            $this->referr = $this->ldap['referrals'];
+            $this->b_user = $this->ldap['bind_user'];
+            $this->b_pass = $this->ldap['bind_pass'];
+
+
             $this->filter = $this->ldap['filter'];
             $this->domain = $this->ldap['domain'];
 
@@ -55,8 +60,9 @@ class identiteam extends rcube_plugin
             if ( is_resource($this->conn) )
             {
                 ldap_set_option($this->conn, LDAP_OPT_PROTOCOL_VERSION, 3);
+                ldap_set_option($this->conn, LDAP_OPT_REFERRALS, $this->referr);
 
-                $bound = ldap_bind($this->conn);
+                $bound = ldap_bind($this->conn, $this->b_user, $this->b_pass);
 
                 if ( $bound )
                 {


### PR DESCRIPTION
Hi, I've dowloaded your plugin, but in my specific installation I've had to modify somthings in the code.
I've a Samba4 server which act as an Active Directory server. I usually made requests against its LDAP backend.

Specifically I've made following modifications :
- Added the ability to set authentication credential against LDAP server
- Added LDAP_OPT_REFERRALS option in order to avoid ldap_search -> "Operations error" in certain configurations (Samba4)

Thank you for this very useful plugin.
Gabriele
