### PR TITLE
Remove duplication declaration of $append_subject

### DIFF
--- a/plugins/vacation_sieve/model.php
+++ b/plugins/vacation_sieve/model.php
@@ -23,7 +23,6 @@ class model
 	public $vacation_end = 0;
 	public $vacation_endtime = 12;
 	public $append_subject = true;
-	public $append_subject = true;
 	public $vacation_subject = 'Out of office'; // overwrite in config.inc.php
 	public $vacation_message = 'I am in Holidays...'; // overwrite in config.inc.php
 	public $every = 1;


### PR DESCRIPTION
This was causing:

[01-Dec-2014 23:17:22] PHP Fatal error:  Cannot redeclare model::$append_subject in /usr/share/roundcubemail/plugins/vacation_sieve/model.php on line 26
